### PR TITLE
Fix Windows PermissionError

### DIFF
--- a/android_world/utils/file_utils.py
+++ b/android_world/utils/file_utils.py
@@ -361,7 +361,11 @@ def tmp_directory_from_device(
     yield tmp_directory
 
   finally:
-    shutil.rmtree(tmp_directory)
+    try:
+      shutil.rmtree(tmp_directory)
+    except Exception as e:
+      logging.error("Failed to delete temporary directory: %s with error %s",
+                    tmp_directory, e)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
On Windows platform, when removing the tmp_directory, sometimes there will be a `PermissionError: [WinError 32]`. Not sure why it happens.