### PR TITLE
Specify the week start

### DIFF
--- a/android_world/task_evals/information_retrieval/proto/tasks.textproto
+++ b/android_world/task_evals/information_retrieval/proto/tasks.textproto
@@ -964,7 +964,7 @@ tasks {
 }
 tasks {
   name: "SimpleCalendarEventsInTimeRange"
-  prompt: "Do I have any events between {start_time} and 8pm {date} in Simple Calendar Pro? Answer with the titles only. Assume the week starts from Sunday. If there are multiples titles, format your answer in a comma separated list."
+  prompt: "Do I have any events between {start_time} and 8pm {date} in Simple Calendar Pro? Assume the week starts from Sunday. Answer with the titles only. If there are multiples titles, format your answer in a comma separated list."
   complexity: 1
   relevant_state {
     state {

--- a/android_world/task_evals/information_retrieval/proto/tasks.textproto
+++ b/android_world/task_evals/information_retrieval/proto/tasks.textproto
@@ -964,7 +964,7 @@ tasks {
 }
 tasks {
   name: "SimpleCalendarEventsInTimeRange"
-  prompt: "Do I have any events between {start_time} and 8pm {date} in Simple Calendar Pro? Answer with the titles only. If there are multiples titles, format your answer in a comma separated list."
+  prompt: "Do I have any events between {start_time} and 8pm {date} in Simple Calendar Pro? Answer with the titles only. Assume the week starts from Sunday. If there are multiples titles, format your answer in a comma separated list."
   complexity: 1
   relevant_state {
     state {

--- a/android_world/task_evals/single/calendar/calendar.py
+++ b/android_world/task_evals/single/calendar/calendar.py
@@ -377,7 +377,7 @@ class SimpleCalendarDeleteEventsOnRelativeDay(SimpleCalendarDeleteEvents):
 
   template = (
       "In Simple Calendar Pro, delete all events scheduled for this"
-      " {day_of_week}."
+      " {day_of_week}. Assume the week starts from Sunday."
   )
 
   @classmethod


### PR DESCRIPTION
I notice that there is a reminder `Assume the week starts from Monday.` in tasks like `SimpleCalendarEventsInNextWeek`. However, `SimpleCalendarEventsInTimeRange` and `SimpleCalendarDeleteEventsOnRelativeDay` lake such a reminder.