### PR TITLE
Add comment to README about how to run on Apple Silicon Devices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ ensure a consistent environment.
     You can see the `scripts/run_suite_on_docker.py` script as an example client
     to interact with the Android environment server running in Docker.
 
+### Note for Apple Silicon users
+
+There are known [issues](https://github.com/amrsa1/Android-Emulator-image/issues/10) with installing the required package `emulator` on ARM chips (Apple Silicon). To get around this, if building images locally, you should build images for the AMD64/x86_64 instruction set, by running:
+```zsh
+docker buildx build --platform linux/amd64 -t android-emulator:latest .
+```
+
+Note, running in a Docker container like this, on an Apple Silicon device will run quite slowly compared to running the Android
+Device and Emulator natively (because you end up running an Android Emulator inside a Linux Emulator...).
+
 ## Run the benchmark
 
 Note: **Task Step Limits Update**


### PR DESCRIPTION
- It is not immediately clear that in order to build and run the Docker image, on an Apple Silicon Device, you need to build it for amd64. 
- The reason for this, is because of [issues](https://github.com/amrsa1/Android-Emulator-image/issues/10) with the emulator package on ARM devices. 
- I think it would be helpful to add this small section to the README to clarify this for Apple Silicon users, and save them time during initial setup. 