### PR TITLE
Fix incorrect comment in LlmWrapper docstring

### DIFF
--- a/android_world/agents/infer.py
+++ b/android_world/agents/infer.py
@@ -57,7 +57,7 @@ class LlmWrapper(abc.ABC):
       self,
       text_prompt: str,
   ) -> tuple[str, Optional[bool], Any]:
-    """Calling multimodal LLM with a prompt and a list of images.
+    """Calling text-only LLM with a prompt.
 
     Args:
       text_prompt: Text prompt.


### PR DESCRIPTION
This PR corrects a misleading comment in the LlmWrapper class, which is present in infer.py.
The previous comment incorrectly referred to “Calling multimodal LLM with a prompt and a list of images” under the text-only LLMWrapper section. 
The updated comment now accurately describes that method as calling a text-only LLM.