### PR TITLE
Fix the task ClockStopWatchRunning

### DIFF
--- a/android_world/env/adb_utils.py
+++ b/android_world/env/adb_utils.py
@@ -62,6 +62,7 @@ _PATTERN_TO_ACTIVITY = immutabledict.immutabledict({
     'audio recorder': (
         'com.dimowner.audiorecorder/com.dimowner.audiorecorder.app.welcome.WelcomeActivity'
     ),
+    'nexuslauncher': 'com.google.android.apps.nexuslauncher',
     'google drive|gdrive|drive': (
         'com.google.android.apps.docs/.drive.startup.StartupActivity'
     ),
@@ -88,6 +89,7 @@ _PATTERN_TO_ACTIVITY = immutabledict.immutabledict({
         'com.google.android.apps.googlevoice/com.google.android.apps.googlevoice.SplashActivity'
     ),
     'clock': 'com.google.android.deskclock/com.android.deskclock.DeskClock',
+    'as': 'com.google.android.as' ,
     'google search|google': (
         'com.google.android.googlequicksearchbox/com.google.android.googlequicksearchbox.SearchActivity'
     ),

--- a/android_world/task_evals/single/clock.py
+++ b/android_world/task_evals/single/clock.py
@@ -106,6 +106,18 @@ def _close_clock_app(env: interface.AsyncEnv):
       adb_utils.extract_package_name(adb_utils.get_adb_activity("clock")),
       env.controller,
   )
+  adb_utils.close_app(
+      "as",
+      env.controller,
+  )
+  adb_utils.clear_app_data(
+      adb_utils.extract_package_name(adb_utils.get_adb_activity("as")),
+      env.controller,
+  )
+  adb_utils.close_app(
+       "as",
+      env.controller,
+  )
 
 
 class _ClockEval(task_eval.TaskEval):


### PR DESCRIPTION
In our internal evaluations, we found that after the environment has run many tasks, even though clock-related tasks include reset scripts at the start and end (which reset the Clock app), the information shown in the At a Glance module does not get reset. This can cause evaluation errors, where the model mistakenly believes a timer has already started running. Therefore, we added an additional reset step for the At a Glance component.

The screenshots are presened as follows:
Now we start a stopwatch
<img width="745" height="907" alt="50aa143d-4068-4690-977e-d07686c941bd" src="https://github.com/user-attachments/assets/5ff8a34e-6fd0-4267-8078-0182f0f02f79" />

Now we clear and close the app clock,but at the glance module is still running
<img width="746" height="876" alt="f75bd406-36ff-41ee-8fe4-f8d1859fa1b4" src="https://github.com/user-attachments/assets/b2aecfa9-7cd4-4bd1-90b6-d99f931919b1" />

after we clear the 'as' module , it works
<img width="711" height="855" alt="f9c27097-542c-48e7-8344-629f19fff115" src="https://github.com/user-attachments/assets/85cb0bae-1ea2-4cc3-9c41-95993876eae2" />

