### PR TITLE
docs: reference ClawBench as an external benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ with randomly-generated parameters to create millions of unique task variations.
 
 In addition to the built-in tasks, AndroidWorld also supports the popular web benchmark, MiniWoB++ from [Liu et al.](http://arxiv.org/abs/1802.08802).
 
+### Related external benchmarks
+
+The following independent benchmark is related to AndroidWorld's autonomous-agent evaluation scope but is not integrated with or supported by AndroidWorld:
+
+* **[ClawBench](https://github.com/TIGER-AI-Lab/ClawBench)** — [paper](https://arxiv.org/abs/2604.08523) and [project page](https://claw-bench.com/). It evaluates web and computer-use agents on 283 tasks across 163 live platforms with isolated browser sessions, request-level outcome checks, and recorded action, screenshot, network, and message traces. See the project's own [runner and setup instructions](https://github.com/TIGER-AI-Lab/ClawBench#readme); task definitions are available on [Hugging Face](https://huggingface.co/datasets/NAIL-Group/ClawBench) and mirrored at [TIGER-Lab/ClawBench](https://huggingface.co/datasets/TIGER-Lab/ClawBench).
+
 Key features of AndroidWorld include:
 
 * 📝 **116 diverse tasks** across 20 real-world apps


### PR DESCRIPTION
## Summary

Adds a clearly labeled external benchmark reference beside AndroidWorld's existing MiniWoB++ benchmark note.

The ClawBench entry links its paper, code, project page, and task-definition datasets, and uses neutral wording. It explicitly states that ClawBench is not integrated with or supported by AndroidWorld; no AndroidWorld task, evaluator, environment, or support claim is added.

## Verification

- Documentation-only change to `README.md`
- `git diff --check` passes
- Submitted by `reacher-z`, a ClawBench maintainer; text prepared with OpenAI Codex assistance
- Maintainer edits are enabled on the fork

No issue is closed by this PR.