### PR TITLE
Isolate temporary files during recipe uploads

### DIFF
--- a/android_world/task_evals/utils/user_data_generation.py
+++ b/android_world/task_evals/utils/user_data_generation.py
@@ -21,6 +21,7 @@ import os
 import random
 import re
 import string
+import tempfile
 from android_env import env_interface
 from android_world.env import adb_utils
 from android_world.env import device_constants
@@ -182,21 +183,16 @@ def write_to_gallery(
 def _copy_data_to_device(
     data: str, file_name: str, location: str, env: interface.AsyncEnv
 ):
-  """Copies data to device by first writing locally, then copying.."""
-  temp_storage_location = file_utils.convert_to_posix_path(_TMP, file_name)
-  with open(temp_storage_location, "w") as temp_file:
-    temp_file.write(data)
+  """Copies data to the device using an isolated temporary directory."""
+  with tempfile.TemporaryDirectory(dir=_TMP) as temp_dir:
+    temp_storage_location = file_utils.convert_to_posix_path(temp_dir, file_name)
+    with open(temp_storage_location, "w") as temp_file:
+      temp_file.write(data)
 
-  file_utils.copy_data_to_device(
-      temp_storage_location,
-      location,
-      env.controller,
-  )
-  try:
-    os.remove(temp_storage_location)
-  except FileNotFoundError:
-    logging.warning(
-        "Local file %s not found, so cannot remove it.", temp_storage_location
+    file_utils.copy_data_to_device(
+        temp_storage_location,
+        location,
+        env.controller,
     )
 
 

--- a/android_world/task_evals/utils/user_data_generation_test.py
+++ b/android_world/task_evals/utils/user_data_generation_test.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import tempfile
+from unittest import mock
 from absl.testing import absltest
 from android_world.task_evals.utils import user_data_generation
 from android_world.utils import file_utils
@@ -37,6 +39,58 @@ def get_video_properties(file_path: str) -> tuple[int, float]:
   cap.release()
 
   return total_frames, fps
+
+
+class TestCopyDataToDevice(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.temp_dir = self.enter_context(tempfile.TemporaryDirectory())
+    self.enter_context(
+        mock.patch.object(user_data_generation, "_TMP", self.temp_dir)
+    )
+    self.enter_context(
+        mock.patch.object(user_data_generation.adb_utils, "close_app")
+    )
+
+  def test_overlapping_uploads_keep_separate_files(self):
+    first_env, second_env = mock.Mock(), mock.Mock()
+    paths, contents = [], []
+
+    def copy(local_path, location, controller):
+      paths.append(local_path)
+      self.assertEqual(os.path.basename(local_path), "recipes.txt")
+      self.assertEqual(
+          location, user_data_generation.device_constants.MARKOR_DATA
+      )
+      if controller is first_env.controller:
+        # Complete another upload while the first still needs its local file.
+        user_data_generation.write_to_markor(
+            "second recipe", "recipes.txt", second_env
+        )
+      with open(local_path) as f:
+        contents.append(f.read())
+
+    with mock.patch.object(file_utils, "copy_data_to_device", side_effect=copy):
+      user_data_generation.write_to_markor(
+          "first recipe", "recipes.txt", first_env
+      )
+
+    self.assertEqual(contents, ["second recipe", "first recipe"])
+    self.assertLen(set(paths), 2)
+    self.assertEmpty(os.listdir(self.temp_dir))
+
+  def test_failed_upload_cleans_up_local_file(self):
+    with mock.patch.object(
+        file_utils, "copy_data_to_device", side_effect=RuntimeError("push failed")
+    ) as copy:
+      with self.assertRaisesRegex(RuntimeError, "push failed"):
+        user_data_generation.write_to_markor(
+            "recipe contents", "recipes.txt", mock.Mock()
+        )
+
+    copy.assert_called_once()
+    self.assertEmpty(os.listdir(self.temp_dir))
 
 
 class TestCreateMpegWithMessages(absltest.TestCase):


### PR DESCRIPTION
Fixes #367.

Stage each Markor upload in its own temporary directory while preserving the destination filename. This prevents overlapping tasks from overwriting or deleting each other's `recipes.txt`, and cleans up local files when a transfer fails.

Both new regression tests fail on upstream and pass with this change. All 23 related tests pass:

```sh
python -m unittest android_world.task_evals.utils.user_data_generation_test android_world.utils.file_utils_test android_world.task_evals.single.recipe_test
```

Syntax and diff checks also pass. Emulator integration was not run.
